### PR TITLE
Stripping white spaces out of secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.57.0  # MSRV
+          - 1.58.0  # MSRV
 
     steps:
       - name: Checkout

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.57.0  # MSRV
+          - 1.58.0  # MSRV
 
     steps:
       - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ release : src
 gresource:
 	glib-compile-resources data/uk.co.grumlimited.authenticator-rs.xml
 
+test:
+	cargo test
+
 run: gresource
 	cargo run
 


### PR DESCRIPTION
Sometimes websites and other providers display the OTP secret with space-separated groups. It's nice but annoying to copy and paste.
This PR simply strips out `\s` out of that string.