### PR TITLE
Makefile: use sharedir and PREFIX consistently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,50 +41,47 @@ release-version:
 	sed -i 's/#VERSION_NUMBER#/$(RELEASE_VERSION)/' ./data/resources/gtk/ui/main.ui
 
 install-po: # dev only - run with sudo
-	msgfmt po/fr.po -o /usr/share/locale/fr/LC_MESSAGES/authenticator-rs.mo
-	msgfmt po/en_GB.po -o /usr/share/locale/en_GB/LC_MESSAGES/authenticator-rs.mo
+	msgfmt po/fr.po -o $(sharedir)/locale/fr/LC_MESSAGES/authenticator-rs.mo
+	msgfmt po/en_GB.po -o $(sharedir)/locale/en_GB/LC_MESSAGES/authenticator-rs.mo
 
-# Install onto the system
-install : release gresource
-	# Create the bindir, if need be
-	mkdir -p $(bindir)
-	# Install binary
-	$(INSTALL_PROGRAM) target/release/authenticator-rs $(bindir)/authenticator-rs
-
-	# Create the sharedir and subfolders, if need be
-	mkdir -p $(sharedir)/icons/hicolor/scalable/apps/
-	mkdir -p $(sharedir)/icons/hicolor/64x64/apps/
-	mkdir -p $(sharedir)/icons/hicolor/128x128/apps/
-	mkdir -p $(sharedir)/applications/
-	mkdir -p $(sharedir)/metainfo/
-	mkdir -p $(sharedir)/uk.co.grumlimited.authenticator-rs/
-	mkdir -p $(sharedir)/glib-2.0/schemas/
-
+install-gresource: gresource
 	# Install gResource
+	mkdir -p $(sharedir)/uk.co.grumlimited.authenticator-rs/
 	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.gresource $(sharedir)/uk.co.grumlimited.authenticator-rs/uk.co.grumlimited.authenticator-rs.gresource
-	
+
 	# Install icons
+	mkdir -p $(sharedir)/icons/hicolor/scalable/apps/
 	$(INSTALL_DATA) data/icons/hicolor/scalable/apps/uk.co.grumlimited.authenticator-rs.svg $(sharedir)/icons/hicolor/scalable/apps/uk.co.grumlimited.authenticator-rs.svg
+	mkdir -p $(sharedir)/icons/hicolor/64x64/apps/
 	$(INSTALL_DATA) data/icons/hicolor/64x64/apps/uk.co.grumlimited.authenticator-rs.64.png $(sharedir)/icons/hicolor/64x64/apps/uk.co.grumlimited.authenticator-rs.png
+	mkdir -p $(sharedir)/icons/hicolor/128x128/apps/
 	$(INSTALL_DATA) data/icons/hicolor/128x128/apps/uk.co.grumlimited.authenticator-rs.128.png $(sharedir)/icons/hicolor/128x128/apps/uk.co.grumlimited.authenticator-rs.png
 
 	# Force icon cache refresh
 	touch $(sharedir)/icons/hicolor
 
-	# Install application meta-data
+	# Install application metadata
+	mkdir -p $(sharedir)/metainfo/
 	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.appdata.xml $(sharedir)/metainfo/uk.co.grumlimited.authenticator-rs.appdata.xml
 
 	# Install desktop file
+	mkdir -p $(sharedir)/applications/
 	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.desktop $(sharedir)/applications/uk.co.grumlimited.authenticator-rs.desktop
 
 	# Install gschema file
+	mkdir -p $(sharedir)/glib-2.0/schemas/
 	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.gschema.xml $(sharedir)/glib-2.0/schemas/
-	
+
 	# Install LOCALE files
 	rm -fr builddir/
-	meson builddir --prefix=/usr
-	DESTDIR=../build-aux/i18n meson install -C builddir
-	cp -fr build-aux/i18n/usr $(DESTDIR)
+	meson setup builddir --prefix=$(PREFIX)
+	meson install -C builddir --destdir=$(DESTDIR)
+
+# Install onto the system
+install : release install-gresource
+	# Install binary
+	mkdir -p $(bindir)
+	$(INSTALL_PROGRAM) target/release/authenticator-rs $(bindir)/authenticator-rs
 
 # Remove an existing install from the system
 uninstall :
@@ -93,7 +90,7 @@ uninstall :
 	# Remove the application metadata
 	rm -f $(sharedir)/metainfo/uk.co.grumlimited.authenticator-rs.appdata.xml
 	# Remove gschema
-	rm -f /usr/share/glib-2.0/schemas/uk.co.grumlimited.authenticator-rs.gschema.xml
+	rm -f $(sharedir)/glib-2.0/schemas/uk.co.grumlimited.authenticator-rs.gschema.xml
 	# Remove the icon
 	rm -f $(sharedir)/icons/hicolor/scalable/apps/uk.co.grumlimited.authenticator-rs.svg
 	rm -f $(sharedir)/icons/hicolor/64x64/apps/uk.co.grumlimited.authenticator-rs.png
@@ -102,7 +99,7 @@ uninstall :
 	rm -f $(bindir)/bin/authenticator-rs
 
 	# Remove LOCALE files
-	find /usr/share/locale/ -name authenticator-rs.mo -exec rm {} \;
+	find $(sharedir)/locale/ -name authenticator-rs.mo -exec rm {} \;
 
 # Remove all files
 clean-all : clean


### PR DESCRIPTION
Mixing raw `/usr` and `PREFIX` means that setting `PREFIX` (and `DESTDIR`) doesn't do what's expected. Instead, use the variables consistently so that building with a different `PREFIX` and `DESTDIR` is possible.

I also put the installation of metadata assets into its own target, so that it can be invoked without attempting to build and install the application itself.

Thanks for creating this application!