### PR TITLE
Absolute path with Meson

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,20 +52,11 @@ jobs:
 
           mkdir -p ~/.cargo/release
 
-#      - name: Rust toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: ${{ matrix.rust }}
-#          override: true
-#          components: rustfmt, clippy
-
       - name: Create Debian package
         env:
           DESTDIR: '~/authenticator-rs-deb'
         run: |
           mkdir -p $DESTDIR
-#          RELEASE_VERSION=${{ github.event.release.tag_name }} DESTDIR=$DESTDIR make release-version
           RELEASE_VERSION=${{ github.event.release.tag_name }} DESTDIR=$DESTDIR make install-gresource
 
       - name: Upload Debian release
@@ -75,66 +66,3 @@ jobs:
           files: |
             ${{ env.DEB_PKG_NAME }}
             ${{ env.DEB_PKG_NAME }}.md5sum
-
-#  centos:
-#    runs-on: ubuntu-latest
-#    needs: [ci]
-#
-#    steps:
-#      - name: System dependencies
-#        run: |
-#          sudo apt-get update
-#          sudo apt-get install -y sudo make alien
-#
-#      - name: Create CentOS 8 package
-#        run: |
-#          wget https://github.com/grumlimited/authenticator-rs/releases/download/${{ github.event.release.tag_name }}/${DEB_PKG_NAME} -O ${DEB_PKG_NAME}
-#
-#          alien -r -k --scripts --target=x86_64 ${DEB_PKG_NAME}
-#          md5sum ${RPM_PKG_NAME} >> ${RPM_PKG_NAME}.md5sum
-#
-#      - name: Upload CentOS 8 release
-#        uses: softprops/action-gh-release@v1
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          files: |
-#            ${{ env.RPM_PKG_NAME }}
-#            ${{ env.RPM_PKG_NAME }}.md5sum
-#
-#
-#  arch:
-#    runs-on: ubuntu-latest
-#    needs: [ci]
-#
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#
-#      - name: Prepare arch package metadata
-#        run: |
-#          wget -q https://github.com/grumlimited/authenticator-rs/releases/download/${{ github.event.release.tag_name }}/${DEB_PKG_NAME} -O build-aux/arch/authenticator-rs-bin/${DEB_PKG_NAME}
-#
-#          MD5_SUM=$(md5sum build-aux/arch/authenticator-rs-bin/${DEB_PKG_NAME}  | awk '{print $1}')
-#          awk -v q="'" -v MD5_SUM=$MD5_SUM -i inplace 'BEGINFILE{print "md5sums=(" q MD5_SUM q ")"}{print}' build-aux/arch/authenticator-rs-bin/PKGBUILD
-#          awk -i inplace 'BEGINFILE{print "pkgver=${{ github.event.release.tag_name }}"}{print}' build-aux/arch/authenticator-rs-bin/PKGBUILD
-#
-#      - name: Validate PKGBUILD
-#        id: validate-pkgbuild
-#        uses: 2m/arch-pkgbuild-builder@v1.16
-#        with:
-#          debug: true
-#          target: pkgbuild
-#          pkgname: build-aux/arch/authenticator-rs-bin/
-#
-#      - name: Create arch package checksum file
-#        run: |
-#          sudo chown -R $USER .
-#          md5sum build-aux/arch/authenticator-rs-bin/${ARCH_PKG_NAME} >> build-aux/arch/authenticator-rs-bin/${ARCH_PKG_NAME}.md5sum
-#
-#      - name: Upload Arch Linux release
-#        uses: softprops/action-gh-release@v1
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          files: |
-#            build-aux/arch/authenticator-rs-bin/${{ env.ARCH_PKG_NAME }}
-#            build-aux/arch/authenticator-rs-bin/${{ env.ARCH_PKG_NAME }}.md5sum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Create Debian package
         env:
-          DESTDIR: '~/authenticator-rs-deb'
+          DESTDIR: '/tmp/authenticator-rs-deb'
         run: |
           mkdir -p $DESTDIR
           RELEASE_VERSION=${{ github.event.release.tag_name }} DESTDIR=$DESTDIR make install-gresource

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,21 +52,21 @@ jobs:
 
           mkdir -p ~/.cargo/release
 
-      - name: Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
+#      - name: Rust toolchain
+#        uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: ${{ matrix.rust }}
+#          override: true
+#          components: rustfmt, clippy
 
       - name: Create Debian package
         env:
           DESTDIR: '~/authenticator-rs-deb'
         run: |
           mkdir -p $DESTDIR
-          RELEASE_VERSION=${{ github.event.release.tag_name }} DESTDIR=$DESTDIR make release-version
-          RELEASE_VERSION=${{ github.event.release.tag_name }} DESTDIR=$DESTDIR make debian-pkg
+#          RELEASE_VERSION=${{ github.event.release.tag_name }} DESTDIR=$DESTDIR make release-version
+          RELEASE_VERSION=${{ github.event.release.tag_name }} DESTDIR=$DESTDIR make install-gresource
 
       - name: Upload Debian release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,65 +76,65 @@ jobs:
             ${{ env.DEB_PKG_NAME }}
             ${{ env.DEB_PKG_NAME }}.md5sum
 
-  centos:
-    runs-on: ubuntu-latest
-    needs: [ci]
-
-    steps:
-      - name: System dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y sudo make alien
-
-      - name: Create CentOS 8 package
-        run: |
-          wget https://github.com/grumlimited/authenticator-rs/releases/download/${{ github.event.release.tag_name }}/${DEB_PKG_NAME} -O ${DEB_PKG_NAME}
-          
-          alien -r -k --scripts --target=x86_64 ${DEB_PKG_NAME}
-          md5sum ${RPM_PKG_NAME} >> ${RPM_PKG_NAME}.md5sum
-
-      - name: Upload CentOS 8 release
-        uses: softprops/action-gh-release@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          files: |
-            ${{ env.RPM_PKG_NAME }}
-            ${{ env.RPM_PKG_NAME }}.md5sum
-
-
-  arch:
-    runs-on: ubuntu-latest
-    needs: [ci]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Prepare arch package metadata
-        run: |
-          wget -q https://github.com/grumlimited/authenticator-rs/releases/download/${{ github.event.release.tag_name }}/${DEB_PKG_NAME} -O build-aux/arch/authenticator-rs-bin/${DEB_PKG_NAME}
-
-          MD5_SUM=$(md5sum build-aux/arch/authenticator-rs-bin/${DEB_PKG_NAME}  | awk '{print $1}')
-          awk -v q="'" -v MD5_SUM=$MD5_SUM -i inplace 'BEGINFILE{print "md5sums=(" q MD5_SUM q ")"}{print}' build-aux/arch/authenticator-rs-bin/PKGBUILD
-          awk -i inplace 'BEGINFILE{print "pkgver=${{ github.event.release.tag_name }}"}{print}' build-aux/arch/authenticator-rs-bin/PKGBUILD
-
-      - name: Validate PKGBUILD
-        id: validate-pkgbuild
-        uses: 2m/arch-pkgbuild-builder@v1.16
-        with:
-          debug: true
-          target: pkgbuild
-          pkgname: build-aux/arch/authenticator-rs-bin/
-
-      - name: Create arch package checksum file
-        run: |
-          sudo chown -R $USER .
-          md5sum build-aux/arch/authenticator-rs-bin/${ARCH_PKG_NAME} >> build-aux/arch/authenticator-rs-bin/${ARCH_PKG_NAME}.md5sum
-
-      - name: Upload Arch Linux release
-        uses: softprops/action-gh-release@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          files: |
-            build-aux/arch/authenticator-rs-bin/${{ env.ARCH_PKG_NAME }}
-            build-aux/arch/authenticator-rs-bin/${{ env.ARCH_PKG_NAME }}.md5sum
+#  centos:
+#    runs-on: ubuntu-latest
+#    needs: [ci]
+#
+#    steps:
+#      - name: System dependencies
+#        run: |
+#          sudo apt-get update
+#          sudo apt-get install -y sudo make alien
+#
+#      - name: Create CentOS 8 package
+#        run: |
+#          wget https://github.com/grumlimited/authenticator-rs/releases/download/${{ github.event.release.tag_name }}/${DEB_PKG_NAME} -O ${DEB_PKG_NAME}
+#
+#          alien -r -k --scripts --target=x86_64 ${DEB_PKG_NAME}
+#          md5sum ${RPM_PKG_NAME} >> ${RPM_PKG_NAME}.md5sum
+#
+#      - name: Upload CentOS 8 release
+#        uses: softprops/action-gh-release@v1
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          files: |
+#            ${{ env.RPM_PKG_NAME }}
+#            ${{ env.RPM_PKG_NAME }}.md5sum
+#
+#
+#  arch:
+#    runs-on: ubuntu-latest
+#    needs: [ci]
+#
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#
+#      - name: Prepare arch package metadata
+#        run: |
+#          wget -q https://github.com/grumlimited/authenticator-rs/releases/download/${{ github.event.release.tag_name }}/${DEB_PKG_NAME} -O build-aux/arch/authenticator-rs-bin/${DEB_PKG_NAME}
+#
+#          MD5_SUM=$(md5sum build-aux/arch/authenticator-rs-bin/${DEB_PKG_NAME}  | awk '{print $1}')
+#          awk -v q="'" -v MD5_SUM=$MD5_SUM -i inplace 'BEGINFILE{print "md5sums=(" q MD5_SUM q ")"}{print}' build-aux/arch/authenticator-rs-bin/PKGBUILD
+#          awk -i inplace 'BEGINFILE{print "pkgver=${{ github.event.release.tag_name }}"}{print}' build-aux/arch/authenticator-rs-bin/PKGBUILD
+#
+#      - name: Validate PKGBUILD
+#        id: validate-pkgbuild
+#        uses: 2m/arch-pkgbuild-builder@v1.16
+#        with:
+#          debug: true
+#          target: pkgbuild
+#          pkgname: build-aux/arch/authenticator-rs-bin/
+#
+#      - name: Create arch package checksum file
+#        run: |
+#          sudo chown -R $USER .
+#          md5sum build-aux/arch/authenticator-rs-bin/${ARCH_PKG_NAME} >> build-aux/arch/authenticator-rs-bin/${ARCH_PKG_NAME}.md5sum
+#
+#      - name: Upload Arch Linux release
+#        uses: softprops/action-gh-release@v1
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          files: |
+#            build-aux/arch/authenticator-rs-bin/${{ env.ARCH_PKG_NAME }}
+#            build-aux/arch/authenticator-rs-bin/${{ env.ARCH_PKG_NAME }}.md5sum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,12 +52,21 @@ jobs:
 
           mkdir -p ~/.cargo/release
 
+      - name: Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt, clippy
+
       - name: Create Debian package
         env:
-          DESTDIR: '/tmp/authenticator-rs-deb'
+          DESTDIR: '/tmp/authenticator-rs-deb' # keep path absolute - meson has issues with relative paths
         run: |
           mkdir -p $DESTDIR
-          RELEASE_VERSION=${{ github.event.release.tag_name }} DESTDIR=$DESTDIR make install-gresource
+          RELEASE_VERSION=${{ github.event.release.tag_name }} DESTDIR=$DESTDIR make release-version
+          RELEASE_VERSION=${{ github.event.release.tag_name }} DESTDIR=$DESTDIR make debian-pkg
 
       - name: Upload Debian release
         uses: softprops/action-gh-release@v1
@@ -66,3 +75,66 @@ jobs:
           files: |
             ${{ env.DEB_PKG_NAME }}
             ${{ env.DEB_PKG_NAME }}.md5sum
+
+  centos:
+    runs-on: ubuntu-latest
+    needs: [ci]
+
+    steps:
+      - name: System dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y sudo make alien
+
+      - name: Create CentOS 8 package
+        run: |
+          wget https://github.com/grumlimited/authenticator-rs/releases/download/${{ github.event.release.tag_name }}/${DEB_PKG_NAME} -O ${DEB_PKG_NAME}
+          
+          alien -r -k --scripts --target=x86_64 ${DEB_PKG_NAME}
+          md5sum ${RPM_PKG_NAME} >> ${RPM_PKG_NAME}.md5sum
+
+      - name: Upload CentOS 8 release
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            ${{ env.RPM_PKG_NAME }}
+            ${{ env.RPM_PKG_NAME }}.md5sum
+
+
+  arch:
+    runs-on: ubuntu-latest
+    needs: [ci]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Prepare arch package metadata
+        run: |
+          wget -q https://github.com/grumlimited/authenticator-rs/releases/download/${{ github.event.release.tag_name }}/${DEB_PKG_NAME} -O build-aux/arch/authenticator-rs-bin/${DEB_PKG_NAME}
+
+          MD5_SUM=$(md5sum build-aux/arch/authenticator-rs-bin/${DEB_PKG_NAME}  | awk '{print $1}')
+          awk -v q="'" -v MD5_SUM=$MD5_SUM -i inplace 'BEGINFILE{print "md5sums=(" q MD5_SUM q ")"}{print}' build-aux/arch/authenticator-rs-bin/PKGBUILD
+          awk -i inplace 'BEGINFILE{print "pkgver=${{ github.event.release.tag_name }}"}{print}' build-aux/arch/authenticator-rs-bin/PKGBUILD
+
+      - name: Validate PKGBUILD
+        id: validate-pkgbuild
+        uses: 2m/arch-pkgbuild-builder@v1.16
+        with:
+          debug: true
+          target: pkgbuild
+          pkgname: build-aux/arch/authenticator-rs-bin/
+
+      - name: Create arch package checksum file
+        run: |
+          sudo chown -R $USER .
+          md5sum build-aux/arch/authenticator-rs-bin/${ARCH_PKG_NAME} >> build-aux/arch/authenticator-rs-bin/${ARCH_PKG_NAME}.md5sum
+
+      - name: Upload Arch Linux release
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            build-aux/arch/authenticator-rs-bin/${{ env.ARCH_PKG_NAME }}
+            build-aux/arch/authenticator-rs-bin/${{ env.ARCH_PKG_NAME }}.md5sum

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ install-gresource: gresource
 	meson install -C builddir --destdir=$(PWD)$(DESTDIR)
 
 	echo XXX
-	pwd
+	printenv|sort
 	echo XXX
 	ls
 	echo XXX

--- a/Makefile
+++ b/Makefile
@@ -45,42 +45,37 @@ install-po: # dev only - run with sudo
 	msgfmt po/en_GB.po -o $(sharedir)/locale/en_GB/LC_MESSAGES/authenticator-rs.mo
 
 install-gresource: gresource
-	pwd
 	# Install gResource
 	mkdir -p $(sharedir)/uk.co.grumlimited.authenticator-rs/
 	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.gresource $(sharedir)/uk.co.grumlimited.authenticator-rs/uk.co.grumlimited.authenticator-rs.gresource
 
-#	# Install icons
-#	mkdir -p $(sharedir)/icons/hicolor/scalable/apps/
-#	$(INSTALL_DATA) data/icons/hicolor/scalable/apps/uk.co.grumlimited.authenticator-rs.svg $(sharedir)/icons/hicolor/scalable/apps/uk.co.grumlimited.authenticator-rs.svg
-#	mkdir -p $(sharedir)/icons/hicolor/64x64/apps/
-#	$(INSTALL_DATA) data/icons/hicolor/64x64/apps/uk.co.grumlimited.authenticator-rs.64.png $(sharedir)/icons/hicolor/64x64/apps/uk.co.grumlimited.authenticator-rs.png
-#	mkdir -p $(sharedir)/icons/hicolor/128x128/apps/
-#	$(INSTALL_DATA) data/icons/hicolor/128x128/apps/uk.co.grumlimited.authenticator-rs.128.png $(sharedir)/icons/hicolor/128x128/apps/uk.co.grumlimited.authenticator-rs.png
-#
-#	# Force icon cache refresh
-#	touch $(sharedir)/icons/hicolor
-#
-#	# Install application metadata
-#	mkdir -p $(sharedir)/metainfo/
-#	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.appdata.xml $(sharedir)/metainfo/uk.co.grumlimited.authenticator-rs.appdata.xml
-#
-#	# Install desktop file
-#	mkdir -p $(sharedir)/applications/
-#	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.desktop $(sharedir)/applications/uk.co.grumlimited.authenticator-rs.desktop
-#
-#	# Install gschema file
-#	mkdir -p $(sharedir)/glib-2.0/schemas/
-#	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.gschema.xml $(sharedir)/glib-2.0/schemas/
+	# Install icons
+	mkdir -p $(sharedir)/icons/hicolor/scalable/apps/
+	$(INSTALL_DATA) data/icons/hicolor/scalable/apps/uk.co.grumlimited.authenticator-rs.svg $(sharedir)/icons/hicolor/scalable/apps/uk.co.grumlimited.authenticator-rs.svg
+	mkdir -p $(sharedir)/icons/hicolor/64x64/apps/
+	$(INSTALL_DATA) data/icons/hicolor/64x64/apps/uk.co.grumlimited.authenticator-rs.64.png $(sharedir)/icons/hicolor/64x64/apps/uk.co.grumlimited.authenticator-rs.png
+	mkdir -p $(sharedir)/icons/hicolor/128x128/apps/
+	$(INSTALL_DATA) data/icons/hicolor/128x128/apps/uk.co.grumlimited.authenticator-rs.128.png $(sharedir)/icons/hicolor/128x128/apps/uk.co.grumlimited.authenticator-rs.png
+
+	# Force icon cache refresh
+	touch $(sharedir)/icons/hicolor
+
+	# Install application metadata
+	mkdir -p $(sharedir)/metainfo/
+	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.appdata.xml $(sharedir)/metainfo/uk.co.grumlimited.authenticator-rs.appdata.xml
+
+	# Install desktop file
+	mkdir -p $(sharedir)/applications/
+	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.desktop $(sharedir)/applications/uk.co.grumlimited.authenticator-rs.desktop
+
+	# Install gschema file
+	mkdir -p $(sharedir)/glib-2.0/schemas/
+	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.gschema.xml $(sharedir)/glib-2.0/schemas/
 
 	# Install LOCALE files
 	rm -fr builddir/
 	meson setup builddir --prefix=$(PREFIX)
 	meson install -C builddir --destdir=$(DESTDIR)
-
-	echo XXX
-	find $(DESTDIR)
-
 
 # Install onto the system
 install : release install-gresource

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,8 @@ install-gresource: gresource
 	# Install LOCALE files
 	rm -fr builddir/
 	meson setup builddir --prefix=$(PREFIX)
-	meson install -C builddir --destdir=$(DESTDIR)
+	#meson install -C builddir --destdir=$(DESTDIR)
+	meson install -C builddir --destdir=/home/runner/authenticator-rs-deb
 
 	echo XXX
 	pwd

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ INSTALL_PROGRAM=$(INSTALL)
 # Run to install application data, with differing permissions
 INSTALL_DATA=$(INSTALL) -m 644
 
+PWD = $(shell pwd)
+
 # Directories into which to install the various files
 bindir=$(DESTDIR)$(PREFIX)/bin
 sharedir=$(DESTDIR)$(PREFIX)/share
@@ -76,15 +78,14 @@ install-gresource: gresource
 	# Install LOCALE files
 	rm -fr builddir/
 	meson setup builddir --prefix=$(PREFIX)
-	#meson install -C builddir --destdir=$(DESTDIR)
-	meson install -C builddir --destdir=/home/runner/authenticator-rs-deb
+	meson install -C builddir --destdir=$(PWD)$(DESTDIR)
 
-	echo XXX
-	pwd
-	echo XXX
-	ls
-	echo XXX
-	find $(DESTDIR)
+#	echo XXX
+#	pwd
+#	echo XXX
+#	ls
+#	echo XXX
+#	find $(DESTDIR)
 
 
 # Install onto the system

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ install-gresource: gresource
 	# Install LOCALE files
 	rm -fr builddir/
 	meson setup builddir --prefix=$(PREFIX)
+	meson install -C builddir --destdir=~/authenticator-rs-deb
 	meson install -C builddir --destdir=$(DESTDIR)
 
 # Install onto the system

--- a/Makefile
+++ b/Makefile
@@ -45,38 +45,46 @@ install-po: # dev only - run with sudo
 	msgfmt po/en_GB.po -o $(sharedir)/locale/en_GB/LC_MESSAGES/authenticator-rs.mo
 
 install-gresource: gresource
+	pwd
 	# Install gResource
 	mkdir -p $(sharedir)/uk.co.grumlimited.authenticator-rs/
 	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.gresource $(sharedir)/uk.co.grumlimited.authenticator-rs/uk.co.grumlimited.authenticator-rs.gresource
 
-	# Install icons
-	mkdir -p $(sharedir)/icons/hicolor/scalable/apps/
-	$(INSTALL_DATA) data/icons/hicolor/scalable/apps/uk.co.grumlimited.authenticator-rs.svg $(sharedir)/icons/hicolor/scalable/apps/uk.co.grumlimited.authenticator-rs.svg
-	mkdir -p $(sharedir)/icons/hicolor/64x64/apps/
-	$(INSTALL_DATA) data/icons/hicolor/64x64/apps/uk.co.grumlimited.authenticator-rs.64.png $(sharedir)/icons/hicolor/64x64/apps/uk.co.grumlimited.authenticator-rs.png
-	mkdir -p $(sharedir)/icons/hicolor/128x128/apps/
-	$(INSTALL_DATA) data/icons/hicolor/128x128/apps/uk.co.grumlimited.authenticator-rs.128.png $(sharedir)/icons/hicolor/128x128/apps/uk.co.grumlimited.authenticator-rs.png
-
-	# Force icon cache refresh
-	touch $(sharedir)/icons/hicolor
-
-	# Install application metadata
-	mkdir -p $(sharedir)/metainfo/
-	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.appdata.xml $(sharedir)/metainfo/uk.co.grumlimited.authenticator-rs.appdata.xml
-
-	# Install desktop file
-	mkdir -p $(sharedir)/applications/
-	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.desktop $(sharedir)/applications/uk.co.grumlimited.authenticator-rs.desktop
-
-	# Install gschema file
-	mkdir -p $(sharedir)/glib-2.0/schemas/
-	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.gschema.xml $(sharedir)/glib-2.0/schemas/
+#	# Install icons
+#	mkdir -p $(sharedir)/icons/hicolor/scalable/apps/
+#	$(INSTALL_DATA) data/icons/hicolor/scalable/apps/uk.co.grumlimited.authenticator-rs.svg $(sharedir)/icons/hicolor/scalable/apps/uk.co.grumlimited.authenticator-rs.svg
+#	mkdir -p $(sharedir)/icons/hicolor/64x64/apps/
+#	$(INSTALL_DATA) data/icons/hicolor/64x64/apps/uk.co.grumlimited.authenticator-rs.64.png $(sharedir)/icons/hicolor/64x64/apps/uk.co.grumlimited.authenticator-rs.png
+#	mkdir -p $(sharedir)/icons/hicolor/128x128/apps/
+#	$(INSTALL_DATA) data/icons/hicolor/128x128/apps/uk.co.grumlimited.authenticator-rs.128.png $(sharedir)/icons/hicolor/128x128/apps/uk.co.grumlimited.authenticator-rs.png
+#
+#	# Force icon cache refresh
+#	touch $(sharedir)/icons/hicolor
+#
+#	# Install application metadata
+#	mkdir -p $(sharedir)/metainfo/
+#	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.appdata.xml $(sharedir)/metainfo/uk.co.grumlimited.authenticator-rs.appdata.xml
+#
+#	# Install desktop file
+#	mkdir -p $(sharedir)/applications/
+#	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.desktop $(sharedir)/applications/uk.co.grumlimited.authenticator-rs.desktop
+#
+#	# Install gschema file
+#	mkdir -p $(sharedir)/glib-2.0/schemas/
+#	$(INSTALL_DATA) data/uk.co.grumlimited.authenticator-rs.gschema.xml $(sharedir)/glib-2.0/schemas/
 
 	# Install LOCALE files
 	rm -fr builddir/
 	meson setup builddir --prefix=$(PREFIX)
-	meson install -C builddir --destdir=~/authenticator-rs-deb
 	meson install -C builddir --destdir=$(DESTDIR)
+
+	echo XXX
+	pwd
+	echo XXX
+	ls
+	echo XXX
+	find $(DESTDIR)
+
 
 # Install onto the system
 install : release install-gresource

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ INSTALL_PROGRAM=$(INSTALL)
 # Run to install application data, with differing permissions
 INSTALL_DATA=$(INSTALL) -m 644
 
-PWD = $(shell pwd)
-
 # Directories into which to install the various files
 bindir=$(DESTDIR)$(PREFIX)/bin
 sharedir=$(DESTDIR)$(PREFIX)/share
@@ -78,7 +76,7 @@ install-gresource: gresource
 	# Install LOCALE files
 	rm -fr builddir/
 	meson setup builddir --prefix=$(PREFIX)
-	meson install -C builddir --destdir=$(PWD)$(DESTDIR)
+	meson install -C builddir --destdir=$(DESTDIR)
 
 	echo XXX
 	find $(DESTDIR)

--- a/Makefile
+++ b/Makefile
@@ -80,12 +80,12 @@ install-gresource: gresource
 	meson setup builddir --prefix=$(PREFIX)
 	meson install -C builddir --destdir=$(PWD)$(DESTDIR)
 
-#	echo XXX
-#	pwd
-#	echo XXX
-#	ls
-#	echo XXX
-#	find $(DESTDIR)
+	echo XXX
+	pwd
+	echo XXX
+	ls
+	echo XXX
+	find $(DESTDIR)
 
 
 # Install onto the system

--- a/Makefile
+++ b/Makefile
@@ -81,10 +81,6 @@ install-gresource: gresource
 	meson install -C builddir --destdir=$(PWD)$(DESTDIR)
 
 	echo XXX
-	printenv|sort
-	echo XXX
-	ls
-	echo XXX
 	find $(DESTDIR)
 
 


### PR DESCRIPTION
Why
====

The `release.yml` used to set `DESTDIR=~/authenticator-rs-deb`. This used to work just fine. But it would appear that at some point, the base ubuntu image shipping with `meson` started resolving `DESTDIR` to

```
 /home/runner/work/authenticator-rs/authenticator-rs~/authenticator-rs-deb/usr/share/locale/en_GB/LC_MESSAGES
```

Using `DESTDIR=/tmp/authenticator-rs-deb` (ie using an absolute path) fixes the problem.