### PR TITLE
fix(db): upsert accounts by label + group to avoid cross-group collisions

### DIFF
--- a/src/helpers/database.rs
+++ b/src/helpers/database.rs
@@ -253,11 +253,6 @@ impl Database {
         Self::_get_account(stmt, params![account_id])
     }
 
-    pub fn get_account_by_name(connection: &Connection, name: &str) -> Result<Option<Account>> {
-        let stmt = connection.prepare("SELECT id, group_id, label, secret, secret_type FROM accounts WHERE label = ?1")?;
-        Self::_get_account(stmt, params![name])
-    }
-
     fn _get_account<T: Params>(mut statement: Statement, params: T) -> Result<Option<Account>> {
         statement
             .query_row(params, |row| {

--- a/src/helpers/database.rs
+++ b/src/helpers/database.rs
@@ -333,14 +333,17 @@ impl ToSql for SecretType {
 
 #[cfg(test)]
 mod tests {
+    use rusqlite::Connection;
+    use std::sync::{Arc, Mutex};
+
+    use crate::helpers::runner;
+    use crate::helpers::SecretType::LOCAL;
+    use crate::model::{Account, AccountGroup};
+
+    use super::Database;
+
     #[test]
     fn get_account_by_label_and_group_should_not_conflict_across_groups() {
-        use super::Database;
-        use crate::helpers::runner;
-        use crate::helpers::SecretType::LOCAL;
-        use crate::model::Account;
-        use rusqlite::Connection;
-
         let connection = Connection::open_in_memory().unwrap();
         let connection = std::sync::Arc::new(std::sync::Mutex::new(connection));
 
@@ -357,7 +360,7 @@ mod tests {
         Database::save_group(&conn, &mut group1).unwrap();
         Database::save_group(&conn, &mut group2).unwrap();
 
-        // create account with same label in both groups
+        // create an account with the same label in both groups
         let mut acct1 = Account::new(0, group1.id, "same_label", "secret1", LOCAL);
         let mut acct2 = Account::new(0, group2.id, "same_label", "secret2", LOCAL);
 
@@ -372,15 +375,6 @@ mod tests {
         assert_eq!(a1.group_id, group1.id);
         assert_eq!(a2.group_id, group2.id);
     }
-
-    use rusqlite::Connection;
-    use std::sync::{Arc, Mutex};
-
-    use crate::helpers::runner;
-    use crate::helpers::SecretType::LOCAL;
-    use crate::model::{Account, AccountGroup};
-
-    use super::Database;
 
     #[test]
     fn create_new_account_and_new_group() {

--- a/src/helpers/database.rs
+++ b/src/helpers/database.rs
@@ -201,7 +201,7 @@ impl Database {
     }
 
     pub fn upsert_account(connection: &Connection, account: &mut Account) -> Result<u32> {
-        match Self::get_account_by_name(connection, account.label.as_str())? {
+        match Self::get_account_by_label_and_group(connection, account.label.as_str(), account.group_id)? {
             Some(a) => {
                 account.id = a.id;
                 account.secret_type = LOCAL; // so that keyring get updated too
@@ -209,6 +209,11 @@ impl Database {
             }
             None => Self::save_account(connection, account),
         }
+    }
+
+    pub fn get_account_by_label_and_group(connection: &Connection, name: &str, group_id: u32) -> Result<Option<Account>> {
+        let stmt = connection.prepare("SELECT id, group_id, label, secret, secret_type FROM accounts WHERE label = ?1 AND group_id = ?2")?;
+        Self::_get_account(stmt, params![name, group_id])
     }
 
     pub fn save_account(connection: &Connection, account: &mut Account) -> Result<u32> {


### PR DESCRIPTION
What
===

* fix(db): upsert accounts by label + group to avoid cross-group collisions
* test(db): add test to ensure get_account_by_label_and_group doesn't conflict across groups
* refactor(tests): reorganize imports and improve clarity in get_account_by_label_and_group test
